### PR TITLE
Prediction Part

### DIFF
--- a/Music gerenation with Keras and TF.ipynb
+++ b/Music gerenation with Keras and TF.ipynb
@@ -257,7 +257,7 @@
     "    preds = model.predict(x)\n",
     "    x = np.squeeze(x)\n",
     "    x = np.concatenate((x, preds))\n",
-    "    x = x[1:]\n",
+    "    x = x[i:]\n",
     "    x = np.expand_dims(x, axis=0)\n",
     "    preds = np.squeeze(preds)\n",
     "    prediction.append(preds)\n",


### PR DESCRIPTION
Shouldn't the state be **x=x[i:]** instead of **x=x[1:]** because we have to update the sequence in x by shifting it 1 space forward. I might be wrong but right now I think the sequence in x will continue to increase. Im somewhat confused.